### PR TITLE
fix copy/uid copy check for missing mailbox name

### DIFF
--- a/lib/commands/copy.js
+++ b/lib/commands/copy.js
@@ -7,7 +7,7 @@ module.exports = function(connection, parsed, data, callback){
         !parsed.attributes[0] ||
         ["ATOM", "SEQUENCE"].indexOf(parsed.attributes[0].type) < 0 ||
         !parsed.attributes[1] ||
-        ["ATOM", "STRING"].indexOf(parsed.attributes[1].type)
+        ["ATOM", "STRING"].indexOf(parsed.attributes[1].type) < 0
         ){
 
         connection.send({

--- a/lib/commands/uid copy.js
+++ b/lib/commands/uid copy.js
@@ -7,7 +7,7 @@ module.exports = function(connection, parsed, data, callback){
         !parsed.attributes[0] ||
         ["ATOM", "SEQUENCE"].indexOf(parsed.attributes[0].type) < 0 ||
         !parsed.attributes[1] ||
-        ["ATOM", "STRING"].indexOf(parsed.attributes[1].type)
+        ["ATOM", "STRING"].indexOf(parsed.attributes[1].type) < 0
         ){
 
         connection.send({


### PR DESCRIPTION
hi!

we're using hoodiecrow in our integration tests (great stuff, big thanks!) and i've noticed that the check for a missing mailbox name goes off when i want to move a mail using inbox... your opinion on this?

cheers
felix
