### PR TITLE
Add optional trailing asterisk for encoded continuation headers.

### DIFF
--- a/lib/mimeparser.js
+++ b/lib/mimeparser.js
@@ -224,7 +224,10 @@ Parser.prototype.parseValueParams = function(headerValue){
         key = (value.shift() || "").trim().toLowerCase();
         value = value.join("=").replace(/^['"\s]*|['"\s]*$/g, "");
 
-        if((match = key.match(/^([^*]+)\*(\d)?$/))){
+        // This regex allows for an optional trailing asterisk, for headers
+        // which are encoded with lang/charset info as well as a continuation.
+        // See https://tools.ietf.org/html/rfc2231 section 4.1.
+        if((match = key.match(/^([^*]+)\*(\d)?\*?$/))){
             if(!processEncodedWords[match[1]]){
                 processEncodedWords[match[1]] = [];
             }


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc2231 section 4.1 ("Combining Character Set, Language, and Parameter Continuations"), encoding/language info may be combined with parameter continuation, e.g. `filename*1*` for content-type.

Previously, this regex checked for a hard-stop `(\d+)?$` without allowing for the asterisk; this patch alters that to allow for the optional asterisk: `(\d+)?\*?$`