### PR TITLE
Always return the UID for "UID FETCH" requests.

### DIFF
--- a/lib/commands/uid fetch.js
+++ b/lib/commands/uid fetch.js
@@ -78,7 +78,7 @@ module.exports = function(connection, parsed, data, callback){
             params.push({type: "ATOM", value: "FLAGS"});
         }
 
-        if(!flagsExist){
+        if(!uidExist){
             params.push({type: "ATOM", value: "UID"});
         }
 


### PR DESCRIPTION
This looks to just be a typo; the `uidExist` variable was otherwise unused. (rfc: https://tools.ietf.org/html/rfc3501#section-6.4.8)